### PR TITLE
[feature] games endpoint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Ignore Go build artifacts
+*.exe
+*.out
+*.o
+*.a
+*.so
+
+# Ignore compiled binaries
+main
+bin/
+tmp/
+
+# Ignore dependencies (they are installed in the container)
+vendor/
+node_modules/
+
+# Ignore local environment files
+.env
+*.log
+.DS_Store
+
+# Ignore Git files
+.git
+.gitignore
+.github
+
+# Ignore IDE/editor-specific files
+.vscode/
+.idea/
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ go.work.sum
 
 # sqlite
 *.db
+
+# ide
+.vscode

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,9 +1,8 @@
-# build stage
-FROM golang:1.23-alpine AS builder
+FROM golang:1.23
+
 WORKDIR /app
 
-RUN apk add --no-cache gcc musl-dev sqlite sqlite-dev
-
+RUN apt-get update && apt-get install -y sqlite3
 COPY go.mod go.sum ./
 RUN go mod download
 
@@ -11,12 +10,6 @@ COPY . .
 
 RUN go build -o main .
 
-# runtime stage
-FROM alpine:latest
-
-WORKDIR /root/
-RUN apk add --no-cache sqlite
-
-COPY --from=builder /app/main .
 EXPOSE 8080
+
 CMD ["./main"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,9 @@
-FROM golang:1.23
-
+# build stage
+FROM golang:1.23-alpine AS builder
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y sqlite3
+RUN apk add --no-cache gcc musl-dev sqlite sqlite-dev
+
 COPY go.mod go.sum ./
 RUN go mod download
 
@@ -10,6 +11,12 @@ COPY . .
 
 RUN go build -o main .
 
-EXPOSE 8080
+# runtime stage
+FROM alpine:latest
 
+WORKDIR /root/
+RUN apk add --no-cache sqlite
+
+COPY --from=builder /app/main .
+EXPOSE 8080
 CMD ["./main"]

--- a/backend/db/database.go
+++ b/backend/db/database.go
@@ -10,7 +10,16 @@ import (
 func ConnectDB(dbPath string) *gorm.DB {
 	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
 	if err != nil {
-		log.Fatalf("Failed to connnect to the database: %v", err)
+		log.Fatalf("Failed to connect to the database: %v", err)
+	}
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		log.Fatalf("Failed to get database connection: %v", err)
+	}
+	_, err = sqlDB.Exec("PRAGMA foreign_keys=ON;")
+	if err != nil {
+		log.Fatalf("Failed to enable foreign key constraints: %v", err)
 	}
 
 	return db

--- a/backend/handlers/game.go
+++ b/backend/handlers/game.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"mahjong-leaderboard-backend/models"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -13,18 +14,37 @@ type GameHandler struct {
 	DB *gorm.DB
 }
 
+type GameRequest struct {
+	Date          string `json:"date" binding:"required"`
+	WinnerID      *uint  `json:"winner_id" binding:"required"`
+	WinningPoints *uint  `json:"winning_points" binding:"required"`
+}
+
 // create a game
 func (h *GameHandler) CreateGame(c *gin.Context) {
-	var game models.Game
-	if err := c.ShouldBindJSON(&game); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	var request GameRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing required fields in request"})
 		return
 	}
+
+	parsedDate, err := time.Parse(time.RFC3339, request.Date)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid date format, need RFC3339"})
+		return
+	}
+	game := models.Game{
+		Date:          parsedDate,
+		WinnerID:      request.WinnerID,
+		WinningPoints: request.WinningPoints,
+	}
+
+	// TODO: update ot check for valid winner id
 	if err := h.DB.Create(&game).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusCreated, gin.H{"messge": "game created successfully", "game": game})
+	c.JSON(http.StatusCreated, gin.H{"message": "game created successfully", "game": game})
 }
 
 // get a game based on id

--- a/backend/handlers/game.go
+++ b/backend/handlers/game.go
@@ -1,0 +1,44 @@
+package handlers
+
+import (
+	"fmt"
+	"mahjong-leaderboard-backend/models"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+type GameHandler struct {
+	DB *gorm.DB
+}
+
+// create a game
+func (h *GameHandler) CreateGame(c *gin.Context) {
+	var game models.Game
+	if err := c.ShouldBindJSON(&game); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := h.DB.Create(&game).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"messge": "game created successfully", "game": game})
+}
+
+// get a game based on id
+func (h *GameHandler) GetGameByID(c *gin.Context) {
+	id := c.Param("id")
+	var game models.Game
+
+	if err := h.DB.First(&game, id).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("game with id: %v not found", id)})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		}
+		return
+	}
+	c.JSON(http.StatusFound, game)
+}

--- a/backend/handlers/handlers_test/game_test.go
+++ b/backend/handlers/handlers_test/game_test.go
@@ -36,10 +36,9 @@ func TestCreateGame(t *testing.T) {
 		"winner_id":      1,
 		"winning_points": 3,
 	}
-	jsonData, _ := json.Marshal(gameData)
+	jsonBody, _ := json.Marshal(gameData)
 
-	req, _ := http.NewRequest("POST", "/games", bytes.NewBuffer(jsonData))
-
+	req, _ := http.NewRequest("POST", "/games", bytes.NewBuffer(jsonBody))
 	req.Header.Set("Content-Type", "application/json")
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -67,4 +66,18 @@ func TestCreateGame(t *testing.T) {
 	assert.Equal(t, responseStruct.Game.Date, dbGame.Date, "DB date mismatch")
 	assert.Equal(t, responseStruct.Game.WinnerID, dbGame.WinnerID, "DB winner id mismatch")
 	assert.Equal(t, responseStruct.Game.WinningPoints, dbGame.WinningPoints, "DB winning points mismatch")
+
+	// verify missing fields raise errors
+	missingField := map[string]interface{}{
+		"date":      "2025-02-10T14:00:00Z",
+		"winner_id": 1,
+	}
+	jsonBody, _ = json.Marshal(missingField)
+	req = httptest.NewRequest("POST", "/games", bytes.NewBuffer(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp = httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	assert.Equal(t, http.StatusBadRequest, resp.Code, "Expected bad request for missing field")
+
 }

--- a/backend/handlers/handlers_test/game_test.go
+++ b/backend/handlers/handlers_test/game_test.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"mahjong-leaderboard-backend/models"
+	"mahjong-leaderboard-backend/testutils"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type GameResponse struct {
+	Message string      `json:"message"`
+	Game    models.Game `json:"game"`
+}
+
+func TestCreateGame(t *testing.T) {
+
+	testModels := []interface{}{
+		&models.Game{},
+		&models.Player{},
+	}
+
+	db, router, err := testutils.SetupTestEnvironment(testModels)
+	if err != nil {
+		t.Fatalf("Failed to set up test environment %v", err)
+	}
+
+	defer func() { db.Migrator().DropTable(testModels...) }()
+
+	gameData := map[string]interface{}{
+		"date":           "2025-02-10T14:00:00Z",
+		"winner_id":      1,
+		"winning_points": 3,
+	}
+	jsonData, _ := json.Marshal(gameData)
+
+	req, _ := http.NewRequest("POST", "/games", bytes.NewBuffer(jsonData))
+
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	assert.Equal(t, http.StatusCreated, resp.Code, "Expected 201 created")
+
+	var responseStruct GameResponse
+	err = json.Unmarshal(resp.Body.Bytes(), &responseStruct)
+	if err != nil {
+		t.Fatalf("failed to parse response body")
+	}
+
+	assert.NotZero(t, responseStruct.Game.ID, "Expected non-zero game ID")
+
+	assert.NotZero(t, responseStruct.Game.ID, "Expected non-zero game ID")
+	assert.Equal(t, gameData["date"], responseStruct.Game.Date.Format("2006-01-02T15:04:05Z"), "Date mismatch")
+	assert.Equal(t, uint(gameData["winner_id"].(int)), *responseStruct.Game.WinnerID, "Winner ID mismatch")
+	assert.Equal(t, uint(gameData["winning_points"].(int)), *responseStruct.Game.WinningPoints, "Winning Points mismatch")
+
+	// query the db to verify as well
+	var dbGame models.Game
+	if err := db.First(&dbGame, responseStruct.Game.ID).Error; err != nil {
+		t.Fatalf("Game not found in db: %v", err)
+	}
+	assert.Equal(t, responseStruct.Game.ID, dbGame.ID, "DB id mismatch")
+	assert.Equal(t, responseStruct.Game.Date, dbGame.Date, "DB date mismatch")
+	assert.Equal(t, responseStruct.Game.WinnerID, dbGame.WinnerID, "DB winner id mismatch")
+	assert.Equal(t, responseStruct.Game.WinningPoints, dbGame.WinningPoints, "DB winning points mismatch")
+}

--- a/backend/handlers/handlers_test/player_test.go
+++ b/backend/handlers/handlers_test/player_test.go
@@ -22,9 +22,9 @@ func TestCreatePlayer(t *testing.T) {
 	defer func() { db.Migrator().DropTable(testModels...) }() // drop table after test
 
 	playerData := map[string]string{"name": "bob"}
-	jsonData, _ := json.Marshal(playerData)
+	jsonBody, _ := json.Marshal(playerData)
 
-	req, _ := http.NewRequest("POST", "/players", bytes.NewBuffer(jsonData))
+	req, _ := http.NewRequest("POST", "/players", bytes.NewBuffer(jsonBody))
 	req.Header.Set("Content-Type", "application/json")
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -52,5 +52,60 @@ func TestGetPlayerByName(t *testing.T) {
 	router.ServeHTTP(resp, req)
 
 	assert.Equal(t, http.StatusOK, resp.Code, "Expected ok")
+
+}
+
+func TestUpdatePlayerName(t *testing.T) {
+	testModels := []interface{}{&models.Player{}}
+	db, router, err := testutils.SetupTestEnvironment(testModels)
+
+	if err != nil {
+		t.Fatalf("Failed to set up test environment: %v", err)
+	}
+
+	testPlayer1 := models.Player{Name: "bob"}
+	testPlayer2 := models.Player{Name: "linda"}
+
+	db.Create(&testPlayer1)
+	db.Create(&testPlayer2)
+	defer func() { db.Migrator().DropTable(&models.Player{}) }()
+
+	// good update
+	updateData := map[string]string{
+		"current_name": "bob",
+		"new_name":     "bobby",
+	}
+	jsonBody, _ := json.Marshal(updateData)
+
+	req := httptest.NewRequest(http.MethodPut, "/players", bytes.NewBuffer(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+	assert.Equal(t, http.StatusOK, resp.Code, "expect ok code in response")
+
+	// bad update, current name does not exist
+	updateData = map[string]string{
+		"current_name": "no name",
+		"new_name":     "a name",
+	}
+	jsonBody, _ = json.Marshal(updateData)
+	req = httptest.NewRequest("PUT", "/players", bytes.NewBuffer(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp = httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusNotFound, resp.Code, "expect conflict code in response")
+	// bad update, new name already exists
+	updateData = map[string]string{
+		"current_name": "bobby",
+		"new_name":     "linda",
+	}
+	jsonBody, _ = json.Marshal(updateData)
+	req = httptest.NewRequest("PUT", "/players", bytes.NewBuffer(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp = httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	assert.Equal(t, http.StatusConflict, resp.Code, "expect conflict in response")
 
 }

--- a/backend/handlers/handlers_test/player_test.go
+++ b/backend/handlers/handlers_test/player_test.go
@@ -3,31 +3,24 @@ package handlers
 import (
 	"bytes"
 	"encoding/json"
-	"mahjong-leaderboard-backend/handlers"
 	"mahjong-leaderboard-backend/models"
+	"mahjong-leaderboard-backend/testutils"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
-func createTestDB() (*gorm.DB, *gin.Engine) {
-	db, _ := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
-	db.AutoMigrate(&models.Player{})
-
-	router := gin.Default()
-	playerHandler := handlers.PlayerHandler{DB: db}
-	router.POST("/players", playerHandler.CreatePlayer)
-	return db, router
-}
-
 func TestCreatePlayer(t *testing.T) {
-	db, router := createTestDB()
-	defer func() { db.Migrator().DropTable(&models.Player{}) }() // drop table after test
+	testModels := []interface{}{&models.Player{}}
+	db, router, err := testutils.SetupTestEnvironment(testModels)
+	if err != nil {
+		t.Fatalf("Failed to set up test environment: %v", err)
+	}
+
+	defer func() { db.Migrator().DropTable(testModels...) }() // drop table after test
+
 	playerData := map[string]string{"name": "bob"}
 	jsonData, _ := json.Marshal(playerData)
 
@@ -37,10 +30,27 @@ func TestCreatePlayer(t *testing.T) {
 	router.ServeHTTP(resp, req)
 
 	assert.Equal(t, http.StatusCreated, resp.Code, "Expected 201 created")
+}
 
-	var player models.Player
-	err := db.First(&player, "name = ?", "bob").Error
-	assert.Nil(t, err, "Player should exist in database")
-	assert.Equal(t, "bob", player.Name, "Player names should match")
+func TestGetPlayerByName(t *testing.T) {
+	testModels := []interface{}{&models.Player{}}
+	db, router, err := testutils.SetupTestEnvironment(testModels)
+
+	if err != nil {
+		t.Fatalf("Failed to set up test environment: %v", err)
+	}
+
+	testPlayer := models.Player{
+		Name: "bob",
+	}
+
+	db.Create(&testPlayer)
+	defer func() { db.Migrator().DropTable(&models.Player{}) }() // drop table after test
+
+	req := httptest.NewRequest("GET", "/players/bob", nil)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code, "Expected ok")
 
 }

--- a/backend/handlers/player.go
+++ b/backend/handlers/player.go
@@ -42,12 +42,12 @@ func (h *PlayerHandler) GetPlayer(c *gin.Context) {
 	if id, err := strconv.Atoi(identifier); err == nil {
 		// number, so just query by primary key
 		if err := h.DB.First(&player, id).Error; err != nil {
-			c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("id: %v not found", identifier)})
+			c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("id %v not found", identifier)})
 			return
 		}
 	} else {
 		if err := h.DB.Where("name = ?", identifier).First(&player).Error; err != nil {
-			c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("name: %v not found", identifier)})
+			c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("name %v not found", identifier)})
 			return
 		}
 	}
@@ -72,7 +72,7 @@ func (h *PlayerHandler) UpdatePlayer(c *gin.Context) {
 	}
 
 	var existing models.Player
-	if err := h.DB.Where("name = ?", request.NewName).First(&existing).Error; err != nil {
+	if err := h.DB.Where("name = ?", request.NewName).First(&existing).Error; err == nil {
 		c.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("%v already exists", request.NewName)})
 		return
 	}

--- a/backend/main.go
+++ b/backend/main.go
@@ -38,5 +38,5 @@ func main() {
 
 // RunMigrations applies database migrations
 func RunMigrations(db *gorm.DB) error {
-	return db.AutoMigrate(&models.Player{})
+	return db.AutoMigrate(&models.Player{}, &models.Game{})
 }

--- a/backend/models/game.go
+++ b/backend/models/game.go
@@ -1,0 +1,14 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type Game struct {
+	gorm.Model
+	Date          time.Time
+	WinnerID      *uint `gorm:"index" json:"winner_id"`
+	WinningPoints *uint `json:"winning_points"`
+}

--- a/backend/models/game.go
+++ b/backend/models/game.go
@@ -8,7 +8,8 @@ import (
 
 type Game struct {
 	gorm.Model
-	Date          time.Time
-	WinnerID      *uint `gorm:"index;constraint:OnUpdate:CASCADE,OnDelete:SET NULL;foreignKey:WinnerID;references:ID" json:"winner_id"`
-	WinningPoints *uint `json:"winning_points"`
+	Date          time.Time `json:"date"`
+	WinnerID      *uint     `gorm:"index;constraint:OnUpdate:CASCADE,OnDelete:SET NULL;foreignKey:WinnerID;references:ID" json:"winner_id"`
+	Winner        *Player   `gorm:"foreignKey:WinnerID;references:ID"`
+	WinningPoints *uint     `json:"winning_points"`
 }

--- a/backend/models/game.go
+++ b/backend/models/game.go
@@ -9,6 +9,6 @@ import (
 type Game struct {
 	gorm.Model
 	Date          time.Time
-	WinnerID      *uint `gorm:"index" json:"winner_id"`
+	WinnerID      *uint `gorm:"index;constraint:OnUpdate:CASCADE,OnDelete:SET NULL;foreignKey:WinnerID;references:ID" json:"winner_id"`
 	WinningPoints *uint `json:"winning_points"`
 }

--- a/backend/routes/router.go
+++ b/backend/routes/router.go
@@ -11,11 +11,16 @@ import (
 func SetupRouter(db *gorm.DB) *gin.Engine {
 	r := gin.Default()
 	playerHandler := handlers.PlayerHandler{DB: db}
+	gameHandler := handlers.GameHandler{DB: db}
 
 	// Player routes
 	r.GET("/players/:identifier", playerHandler.GetPlayer)
 	r.POST("/players", playerHandler.CreatePlayer)
 	r.PUT("/players", playerHandler.UpdatePlayer)
+
+	// Game routes
+	r.GET("/games/:id", gameHandler.GetGameByID)
+	r.POST("/games", gameHandler.CreateGame)
 
 	return r
 }

--- a/backend/testutils/test_environment.go
+++ b/backend/testutils/test_environment.go
@@ -1,0 +1,40 @@
+package testutils
+
+import (
+	"log"
+	"mahjong-leaderboard-backend/handlers"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func SetupTestEnvironment(models []interface{}) (*gorm.DB, *gin.Engine, error) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	log.Println("created test db in memory")
+
+	if err := db.AutoMigrate(models...); err != nil {
+		return nil, nil, err
+	}
+
+	log.Println("Ran migrations successfully")
+	log.Println("Creating routes")
+	router := gin.Default()
+	// handlers
+	playerHandler := handlers.PlayerHandler{DB: db}
+	gameHandler := handlers.GameHandler{DB: db}
+	// player routes
+	router.GET("/players/:identifier", playerHandler.GetPlayer)
+	router.POST("/players", playerHandler.CreatePlayer)
+	router.PUT("/players", playerHandler.UpdatePlayer)
+	// game routes
+	router.GET("/games/:id", gameHandler.GetGameByID)
+	router.POST("/games", gameHandler.CreateGame)
+
+	return db, router, nil
+
+}


### PR DESCRIPTION
Add basic CRUD operations for a `game`, but will need future design and implementation on the `player`s within the `game`. For now these main changes are:

- `POST` endpoint for logging a game (including who won and how many points)
- `GET` endpoint for getting an individual game by `id`
- Creating a `testutils` package to reuse some setup of test environments